### PR TITLE
* fix broken title in header

### DIFF
--- a/src/css/how.css
+++ b/src/css/how.css
@@ -75,7 +75,7 @@ p {
     font-weight: 400;
     margin: 0 auto;
     line-height: 1.1em;
-    max-width: 9600px;
+    max-width: 960px;
     margin: 0;
 }
 


### PR DESCRIPTION
Olá, reparei que no cabeçalho do site, na tag strong com o conteúdo "Tecnologias front-end" está quebrando em monitores menores. Este fix resolve o problema.
